### PR TITLE
chore: add PR creation and merge commands for Claude Code

### DIFF
--- a/.claude/commands/create-pr-with-merge.md
+++ b/.claude/commands/create-pr-with-merge.md
@@ -1,0 +1,51 @@
+---
+description: "Create a PR and merge it into target branch (default: main) (need gh command)"
+allowed-tools:
+  - "Bash(gh:*)"
+  - "Bash(git:*)"
+argument-hint: "[target-branch]"
+---
+
+Create a pull request from the current branch to the target branch, then squash-merge it.
+Target branch is $ARGUMENTS if provided, otherwise default to main.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Target branch: $ARGUMENTS (default: main)
+- Commits ahead of target: !`git log origin/main..HEAD --oneline`
+- Diff stats: !`git diff origin/main --stat`
+
+## Steps
+
+1. Run `gh auth status` to verify authentication. If not authenticated, tell the user to run `gh auth login` and stop immediately.
+
+2. Determine the target branch. If $ARGUMENTS is provided, use it. Otherwise use main.
+
+3. If there are no commits ahead of the target branch, print "No changes to create PR for." and stop.
+
+4. Run `gh pr list --head <current-branch> --state open` to check for an existing PR. If one exists, print its URL and stop.
+
+5. Push unpushed commits by running `git push origin HEAD`. If push fails, show the error and stop.
+
+6. Generate the PR title and body from the commit log and diff stat. Title should be conventional commit style, single line. Body should summarize changes and scope.
+
+7. Run `gh pr create --base <target-branch> --head <current-branch> --title "<title>" --body "<body>"` and print the created PR URL.
+
+8. Squash-merge the PR and delete the remote branch by running `gh pr merge <pr-url> --squash --delete-branch`. If CI checks are pending, ask the user:
+   - **Wait**: Run `gh pr checks <pr-url> --watch` and then retry the merge.
+   - **Abort**: Stop without merging. Keep the PR open.
+
+9. After successful merge, run `git checkout <target-branch> && git pull origin <target-branch>` to sync the local branch.
+
+10. Print merge result summary: merged PR URL, deleted branch name, and current local state.
+
+## Error Handling
+
+- **Existing PR**: Show the PR URL and stop (not an error).
+- **No diff**: Inform the user there are no changes and stop.
+- **Push failure**: Show the error message and stop.
+- **gh auth failure**: Print `gh auth login` instructions and stop.
+- **CI checks pending**: Ask user whether to wait or abort.
+- **Merge conflict**: Print conflict details, tell the user to resolve manually. Keep the PR open.
+- **Merge failure (any reason)**: Keep the PR open (NEVER delete it on error). Print the PR URL for manual follow-up.

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,40 @@
+---
+description: "Create a PR to merge current branch into target branch (default: main) (need gh command)"
+allowed-tools:
+  - "Bash(gh:*)"
+  - "Bash(git:*)"
+argument-hint: "[target-branch]"
+---
+
+Create a pull request from the current branch to the target branch.
+Target branch is $ARGUMENTS if provided, otherwise default to main.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Target branch: $ARGUMENTS (default: main)
+- Commits ahead of target: !`git log origin/main..HEAD --oneline`
+- Diff stats: !`git diff origin/main --stat`
+
+## Steps
+
+1. Run `gh auth status` to verify authentication. If not authenticated, tell the user to run `gh auth login` and stop immediately.
+
+2. Determine the target branch. If $ARGUMENTS is provided, use it. Otherwise use main.
+
+3. If there are no commits ahead of the target branch, print "No changes to create PR for." and stop.
+
+4. Run `gh pr list --head <current-branch> --state open` to check for an existing PR. If one exists, print its URL and stop.
+
+5. Push unpushed commits by running `git push origin HEAD`. If push fails, show the error and stop.
+
+6. Generate the PR title and body from the commit log and diff stat. Title should be conventional commit style, single line. Body should summarize changes and scope.
+
+7. Run `gh pr create --base <target-branch> --head <current-branch> --title "<title>" --body "<body>"` and print the created PR URL.
+
+## Error Handling
+
+- **Existing PR**: Show the PR URL and stop (not an error).
+- **No diff**: Inform the user there are no changes and stop.
+- **Push failure**: Show the error message and stop.
+- **gh auth failure**: Print `gh auth login` instructions and stop.


### PR DESCRIPTION
## Summary

- Add `create-pr.md` command: create a PR from current branch to target branch (default: main)
- Add `create-pr-with-merge.md` command: create a PR and squash-merge with CI check handling
- Both commands use `gh` CLI with proper auth checks and error handling

## Test plan

- [ ] Run `/create-pr` on a feature branch and verify PR creation
- [ ] Run `/create-pr-with-merge` and verify PR creation + merge flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)