### PR TITLE
docs: translate Japanese text to English for OSS consistency

### DIFF
--- a/.claude/commands/create-ticket.md
+++ b/.claude/commands/create-ticket.md
@@ -5,52 +5,52 @@ description: "Create a new refactoring ticket with Claude Code workflow recommen
 
 # /create-ticket
 
-チケットの説明: $ARGUMENTS
+Ticket description: $ARGUMENTS
 
 ## Instructions
 
-与えられたチケット説明から、構造化されたリファクタリングチケットを生成する。
+Generate a structured refactoring ticket from the given ticket description.
 
-### Phase 1: 調査（researcher agent）
+### Phase 1: Investigation (researcher agent)
 
-researcher agent を使って以下を調査:
+Use the researcher agent to investigate:
 
-1. チケット説明に関連するソースコード (`src/helix/`, `tests/`)
-2. 影響を受けるファイルと行範囲
-3. 既存のテストカバレッジ
-4. 関連するドキュメント (`docs/`)
-5. 依存関係（他チケットとの関連）
+1. Source code related to the ticket description (`src/helix/`, `tests/`)
+2. Affected files and line ranges
+3. Existing test coverage
+4. Related documentation (`docs/`)
+5. Dependencies (relationships with other tickets)
 
-### Phase 2: 計画（planner agent）
+### Phase 2: Planning (planner agent)
 
-planner agent を使って以下を設計:
+Use the planner agent to design:
 
-1. チケットの構造（背景・Scope・Acceptance Criteria・Implementation Notes）
-2. 適切なカテゴリ（Security / CodeQuality / Doc / DevOps / Community）とサイズ（S/M/L/XL）の判定
-3. `.docs/templates/workflow-patterns.md` を参照し、カテゴリ×サイズに基づくワークフロー推奨を生成
+1. Ticket structure (Background, Scope, Acceptance Criteria, Implementation Notes)
+2. Appropriate category (Security / CodeQuality / Doc / DevOps / Community) and size (S/M/L/XL)
+3. Workflow recommendations based on category x size, referencing `.docs/templates/workflow-patterns.md`
 
-### Phase 3: チケット出力
+### Phase 3: Ticket output
 
-以下のフォーマットでチケットを生成し、ユーザーに提示する:
+Generate the ticket in the following format and present it to the user:
 
 ```markdown
-## T-NNN: [タイトル]
+## T-NNN: [Title]
 
-| 項目 | 値 |
-|------|-----|
+| Field | Value |
+|-------|-------|
 | Priority | **P?** |
-| Category | [カテゴリ] |
+| Category | [Category] |
 | Size | [S/M/L/XL] |
-| Dependencies | [依存チケット or —] |
+| Dependencies | [Dependent tickets or —] |
 
-### 背景
+### Background
 
-[問題の説明と根拠]
+[Problem description and rationale]
 
 ### Scope
 
-| ファイル | 行 | 変更内容 |
-|----------|-----|---------|
+| File | Lines | Change |
+|------|-------|--------|
 | ... | ... | ... |
 
 ### Acceptance Criteria
@@ -64,29 +64,29 @@ planner agent を使って以下を設計:
 
 ### Claude Code Workflow
 
-| Phase | Command / Agent | 目的 |
-|-------|----------------|------|
+| Phase | Command / Agent | Purpose |
+|-------|----------------|---------|
 | 1. ... | ... | ... |
 
-**実行例**:
+**Example execution**:
 ```
-[コマンドフロー]
+[Command flow]
 ```
 ```
 
-### ワークフロー選択ガイド
+### Workflow selection guide
 
-利用可能なコマンド・エージェントを `.claude/commands/` と `.claude/agents/` から読み取り、
-`.docs/templates/workflow-patterns.md` のパターンを参照してワークフローを設計すること。
+Read available commands and agents from `.claude/commands/` and `.claude/agents/`,
+and reference patterns in `.docs/templates/workflow-patterns.md` to design the workflow.
 
-**カテゴリ別の基本方針**:
-- **Security**: `/security-scan` を前後に挟む。spec-first でドキュメント先行。
-- **CodeQuality**: `/refactor` コマンドを活用。振る舞い変更なしを保証。
-- **Doc**: doc-writer agent を活用。
-- **DevOps**: CI/CD設定はテスト困難なため `/plan` で慎重に設計。
-- **Community**: 業界標準テンプレートを参照。
+**Category-specific guidelines**:
+- **Security**: Wrap with `/security-scan` before and after. Spec-first with documentation leading.
+- **CodeQuality**: Use `/refactor` command. Guarantee no behavior changes.
+- **Doc**: Use doc-writer agent.
+- **DevOps**: CI/CD configs are hard to test; design carefully with `/plan`.
+- **Community**: Reference industry-standard templates.
 
-**サイズ別の方針**:
-- **S**: `/plan` 省略可。直接実装。
-- **M**: `/plan` 推奨。
-- **L/XL**: `/plan` 必須。段階実装を推奨。
+**Size-specific guidelines**:
+- **S**: `/plan` optional. Direct implementation.
+- **M**: `/plan` recommended.
+- **L/XL**: `/plan` required. Incremental implementation recommended.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ PYTHONPATH=src UV_CACHE_DIR=.uv-cache uv run --no-sync --no-editable python -m p
 - Security and operations readiness: signing/encryption and operator tooling (`doctor`, `snapshot`, `restore`).
 - Stable format governance and backward-compatibility policy for long-lived seed archives.
 
+## Installation
+
+> **Note**: PyPI publishing is currently on hold. `pip install helix` is not yet available.
+> Please install from source.
+
 ## Quick Start
 ```bash
 uv sync --no-editable --extra dev

--- a/docs/RISK_MITIGATION_PLAN.md
+++ b/docs/RISK_MITIGATION_PLAN.md
@@ -24,18 +24,18 @@ Priority scale:
 ## Risk Register and Mitigation Summary
 | ID | Priority | Risk | Primary Control | Success KPI |
 |---|---|---|---|---|
-| R-01 | P0 | Genome欠損で復元不能 | strict verify + genome snapshot/restore | DR演習で復元成功率100% |
-| R-02 | P0 | CRC中心で改ざん耐性が弱い | section SHA-256 + optional signature | 改ざんケース検知率100% |
-| R-03 | P0 | seed公開時の情報漏えい | encryption + manifest minimization | 鍵なし復号不可、メタ露出最小化 |
-| R-04 | P1 | CIDがあっても取得不能 | pin strategy + fetch retry/fallback | fetch成功率99.9%以上 |
-| R-05 | P1 | 運用環境差で失敗しやすい | helix doctor + actionable errors | 一次切り分け時間50%短縮 |
-| R-06 | P1 | 将来の互換性破壊 | compatibility policy + fixture tests | 旧seed回帰テスト常時緑 |
-| R-07 | P2 | 性能/コスト劣化 | benchmark gates + storage tuning | 閾値割れPRの自動検知 |
-| R-08 | P2 | OSS維持体制の持続性不足 | support/donation guidance + maintainer workflow | 継続支援指標の可視化 |
+| R-01 | P0 | Unrecoverable restoration due to missing genome | strict verify + genome snapshot/restore | 100% restore success in DR drills |
+| R-02 | P0 | Weak tamper resistance (CRC-centric) | section SHA-256 + optional signature | 100% tamper detection rate |
+| R-03 | P0 | Information leakage on seed publication | encryption + manifest minimization | Decryption impossible without key; metadata exposure minimized |
+| R-04 | P1 | Retrieval failure despite valid CID | pin strategy + fetch retry/fallback | Fetch success rate >= 99.9% |
+| R-05 | P1 | Operational failures due to environment differences | helix doctor + actionable errors | 50% reduction in initial triage time |
+| R-06 | P1 | Future backward-compatibility breakage | compatibility policy + fixture tests | Legacy seed regression tests always green |
+| R-07 | P2 | Performance/cost degradation | benchmark gates + storage tuning | Auto-detection of threshold-violating PRs |
+| R-08 | P2 | Insufficient OSS sustainability | support/donation guidance + maintainer workflow | Sustainability metrics visible |
 
 ## Detailed Mitigation Plans
 
-### R-01 (P0) Genome欠損で復元不能
+### R-01 (P0) Unrecoverable restoration due to missing genome
 Objective:
 - Prevent decode failures caused by missing referenced chunks.
 
@@ -52,7 +52,7 @@ Deliverables:
 Acceptance criteria:
 - Simulated loss of genome can be recovered from snapshot with zero data loss.
 
-### R-02 (P0) 改ざん耐性不足
+### R-02 (P0) Insufficient tamper resistance
 Objective:
 - Strengthen seed tamper detection beyond CRC.
 
@@ -69,7 +69,7 @@ Deliverables:
 Acceptance criteria:
 - Any modified section causes verification failure in cryptographic mode.
 
-### R-03 (P0) 機密性リスク
+### R-03 (P0) Confidentiality risk
 Objective:
 - Reduce plaintext leakage when sharing/publishing seeds.
 
@@ -86,7 +86,7 @@ Deliverables:
 Acceptance criteria:
 - Encrypted seed cannot be decoded without key material.
 
-### R-04 (P1) IPFS可用性
+### R-04 (P1) IPFS availability
 Objective:
 - Improve retrieval reliability across nodes and time.
 
@@ -103,7 +103,7 @@ Deliverables:
 Acceptance criteria:
 - Controlled outage simulation still meets fetch success target.
 
-### R-05 (P1) 運用失敗率
+### R-05 (P1) Operational failure rate
 Objective:
 - Make failures self-diagnosable for non-expert operators.
 
@@ -119,7 +119,7 @@ Deliverables:
 Acceptance criteria:
 - Top 10 failure scenarios are diagnosable from doctor + one command.
 
-### R-06 (P1) 互換性管理
+### R-06 (P1) Compatibility management
 Objective:
 - Avoid accidental breakage of existing seeds when evolving format.
 
@@ -135,7 +135,7 @@ Deliverables:
 Acceptance criteria:
 - Historical fixtures continue parsing and verifying in CI.
 
-### R-07 (P2) 性能/コスト
+### R-07 (P2) Performance/cost
 Objective:
 - Keep dedup ratio and throughput stable as code evolves.
 
@@ -151,7 +151,7 @@ Deliverables:
 Acceptance criteria:
 - PRs exceeding regression budget are blocked.
 
-### R-08 (P2) OSS持続性リスク
+### R-08 (P2) OSS sustainability risk
 Objective:
 - Define a sustainable OSS support boundary without restricting OSS core.
 


### PR DESCRIPTION
## Summary
- Translate all Japanese text to English in git-tracked files
- Add PyPI publishing on-hold note to README.md

## Changed Files
- `.claude/commands/create-ticket.md` — all instructions translated
- `docs/RISK_MITIGATION_PLAN.md` — risk descriptions and section headers translated
- `README.md` — added Installation section with PyPI on-hold note

🤖 Generated with [Claude Code](https://claude.com/claude-code)