### PR TITLE
feat: add /ship skill combining commit + PR + optional merge

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ship
+description: >-
+  Commit current changes, create a PR, and optionally squash-merge.
+  Combines commit + create-pr + merge into a single workflow.
+  Use when the user wants to ship completed work.
+disable-model-invocation: true
+allowed-tools:
+  - "Bash(git add:*)"
+  - "Bash(git commit:*)"
+  - "Bash(git status:*)"
+  - "Bash(git diff:*)"
+  - "Bash(git log:*)"
+  - "Bash(git push:*)"
+  - "Bash(git checkout:*)"
+  - "Bash(git pull:*)"
+  - "Bash(git branch:*)"
+  - "Bash(gh:*)"
+argument-hint: "[target-branch] [merge=true]"
+---
+
+Ship the current changes: commit, create PR, and optionally merge.
+User arguments: $ARGUMENTS
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` for positional arguments:
+- First argument: target branch name (default: `main`). If the first argument is `true` or `merge=true`, treat it as the merge flag and use `main` as target.
+- Second argument: `merge=true` or `true` to enable squash-merge after PR creation (default: no merge).
+
+Examples:
+- `/ship` → commit + PR to main
+- `/ship develop` → commit + PR to develop
+- `/ship merge=true` → commit + PR to main + squash-merge
+- `/ship main true` → commit + PR to main + squash-merge
+- `/ship develop merge=true` → commit + PR to develop + squash-merge
+
+## Pre-computed Context
+
+Current branch:
+!`git branch --show-current`
+
+Current state:
+!`git status --short`
+
+Staged diff:
+!`git diff --cached`
+
+Unstaged diff summary:
+!`git diff --stat`
+
+Diff stats vs main:
+!`git diff origin/main --stat`
+
+Recent commits for style reference:
+!`git log --oneline -10`
+
+Commits ahead of main:
+!`git log origin/main..HEAD --oneline`
+
+## Phase 1: Commit
+
+1. Analyze staged and unstaged changes.
+2. If there are no changes at all (nothing staged, nothing unstaged, no untracked files), print "No changes to ship." and stop.
+3. If there are unstaged or untracked changes, show the file list and ask the user which files to stage. Exclude files matching: `.env*`, `*credentials*`, `*secret*`, `*.key`, `*.pem` — warn the user if such files are present.
+4. Generate a conventional commit message (feat/fix/improve/chore/docs/test/perf). Focus on the "why", not the "what". Use a HEREDOC for the message.
+5. Run `git status` to verify the commit succeeded.
+
+## Phase 2: Create PR
+
+6. Run `gh auth status`. If not authenticated, tell the user to run `gh auth login` and stop.
+7. Determine the target branch from arguments (default: main). If the target is not main, re-run `git log` and `git diff` against the actual target branch (the pre-computed context above is always against main).
+8. Check commits ahead of target: `git log origin/<target>..HEAD --oneline`. If there are no commits ahead, print "No commits ahead of target branch." and stop.
+9. Run `gh pr list --head <current-branch> --state open` to check for an existing PR. If one exists, capture the PR URL, print it, and skip to Phase 3 (if merge is enabled) or stop.
+10. Push with `git push origin HEAD`. On failure, show the error and stop.
+11. Generate PR title (conventional commit style, single line) and body (summarize changes and scope) from the commit log and diff.
+12. Create the PR with `gh pr create --base <target-branch> --head <current-branch> --title "<title>" --body "<body>"`.
+13. Print the PR URL. If merge is not enabled, stop here. Note: when squash-merged, the PR title becomes the commit message on the target branch.
+
+## Phase 3: Merge (only when merge=true)
+
+14. Attempt `gh pr merge <pr-url> --squash --delete-branch`.
+15. If merge fails due to pending CI checks, ask the user to choose one of:
+    - **Wait**: Run `gh pr checks <pr-number> --watch`, then retry the merge.
+    - **Force**: Run `gh pr merge <pr-url> --squash --delete-branch --admin` to bypass checks. Note: requires admin permissions on the repository — if this fails, inform the user and keep the PR open.
+    - **Skip**: Stop without merging. Print the PR URL for manual follow-up.
+16. After successful merge, sync local: `git checkout <target-branch> && git pull origin <target-branch>`.
+17. Print summary: merged PR URL, deleted branch name, current local state.
+
+## Error Handling
+
+- **No changes**: Print "No changes to ship." and stop.
+- **No commits ahead**: Print "No commits ahead of target branch." and stop.
+- **gh auth failure**: Print `gh auth login` instructions and stop.
+- **Push failure**: Show the error and stop.
+- **Existing PR (merge disabled)**: Show the PR URL and stop.
+- **Existing PR (merge enabled)**: Capture the PR URL and proceed to Phase 3.
+- **CI checks pending**: Ask user to choose Wait / Force / Skip (Phase 3 step 15).
+- **Force merge failure (no admin)**: Inform user, keep PR open, print URL.
+- **Merge conflict**: Print details, keep PR open, stop.
+- **Merge failure (any reason)**: Keep PR open, print PR URL for manual follow-up.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --no-editable --extra dev
       - name: Install Kubo
-        uses: ipfs/download-ipfs-distribution-action@v1
-        with:
-          name: kubo
-          version: v0.32.1
+        run: |
+          KUBO_VERSION="v0.34.1"
+          ARCHIVE="kubo_${KUBO_VERSION}_linux-amd64.tar.gz"
+          URL="https://github.com/ipfs/kubo/releases/download/${KUBO_VERSION}/${ARCHIVE}"
+          curl -fsSL "${URL}" -o /tmp/kubo.tgz
+          tar -xzf /tmp/kubo.tgz -C /tmp
+          sudo install -m 0755 /tmp/kubo/ipfs /usr/local/bin/ipfs
+          ipfs --version
       - name: Start kubo daemon
         run: |
           ipfs init

--- a/.github/workflows/publish-seed.yml
+++ b/.github/workflows/publish-seed.yml
@@ -45,7 +45,7 @@ on:
         description: "Kubo version to install when dry_run=false"
         required: true
         type: string
-        default: "0.32.1"
+        default: "0.34.1"
       pin:
         description: "Pin after publish"
         required: true

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
-from seedbraid.chunking import ChunkerConfig, chunk_bytes
+import functools
+import hashlib
+import io
+
+from seedbraid.chunking import (
+    ChunkerConfig,
+    chunk_bytes,
+    iter_cdc_buzhash,
+)
+
+_CFG_SHIFT = ChunkerConfig(
+    min_size=512, avg_size=2048, max_size=8192, window_size=32
+)
+_INSERT_OFFSET = 10_000
+_DATA_BLOCKS = 4_000  # SHA-256 blocks (125 KiB)
 
 
 def test_cdc_buzhash_deterministic_boundaries() -> None:
@@ -25,3 +39,53 @@ def test_cdc_rabin_deterministic_boundaries() -> None:
     second = chunk_bytes(data, "cdc_rabin", cfg)
 
     assert first == second
+
+
+@functools.lru_cache(maxsize=1)
+def _make_data() -> bytes:
+    return b"".join(
+        hashlib.sha256(i.to_bytes(4, "big")).digest()
+        for i in range(_DATA_BLOCKS)
+    )
+
+
+def _chunks_before_offset(
+    chunks: list[bytes], offset: int
+) -> list[bytes]:
+    result: list[bytes] = []
+    pos = 0
+    for c in chunks:
+        if pos + len(c) <= offset:
+            result.append(c)
+            pos += len(c)
+        else:
+            break
+    return result
+
+
+def test_cdc_buzhash_shift_resilient_prefix() -> None:
+    data = _make_data()
+    shifted = (
+        data[:_INSERT_OFFSET]
+        + b"\xff"
+        + data[_INSERT_OFFSET:]
+    )
+
+    orig = list(iter_cdc_buzhash(io.BytesIO(data), _CFG_SHIFT))
+    shifted_chunks = list(
+        iter_cdc_buzhash(io.BytesIO(shifted), _CFG_SHIFT)
+    )
+
+    assert len(orig) >= 2, "Not enough chunks to test"
+
+    pre_orig = _chunks_before_offset(orig, _INSERT_OFFSET)
+    pre_shifted = _chunks_before_offset(
+        shifted_chunks, _INSERT_OFFSET
+    )
+
+    assert len(pre_orig) >= 1, (
+        "No chunks before insert point"
+    )
+    assert pre_orig == pre_shifted, (
+        "Chunks before insert point changed after insertion"
+    )

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -8,6 +8,7 @@ from seedbraid.chunking import (
     ChunkerConfig,
     chunk_bytes,
     iter_cdc_buzhash,
+    iter_cdc_rabin,
 )
 
 _CFG_SHIFT = ChunkerConfig(
@@ -49,6 +50,16 @@ def _make_data() -> bytes:
     )
 
 
+@functools.lru_cache(maxsize=1)
+def _make_shifted() -> bytes:
+    data = _make_data()
+    return (
+        data[:_INSERT_OFFSET]
+        + b"\xff"
+        + data[_INSERT_OFFSET:]
+    )
+
+
 def _chunks_before_offset(
     chunks: list[bytes], offset: int
 ) -> list[bytes]:
@@ -63,22 +74,23 @@ def _chunks_before_offset(
     return result
 
 
-def test_cdc_buzhash_shift_resilient_prefix() -> None:
+def _assert_prefix_invariant(chunker_fn) -> None:
+    """Chunks before the 1-byte insert point stay identical."""
     data = _make_data()
-    shifted = (
-        data[:_INSERT_OFFSET]
-        + b"\xff"
-        + data[_INSERT_OFFSET:]
-    )
+    shifted = _make_shifted()
 
-    orig = list(iter_cdc_buzhash(io.BytesIO(data), _CFG_SHIFT))
+    orig = list(
+        chunker_fn(io.BytesIO(data), _CFG_SHIFT)
+    )
     shifted_chunks = list(
-        iter_cdc_buzhash(io.BytesIO(shifted), _CFG_SHIFT)
+        chunker_fn(io.BytesIO(shifted), _CFG_SHIFT)
     )
 
     assert len(orig) >= 2, "Not enough chunks to test"
 
-    pre_orig = _chunks_before_offset(orig, _INSERT_OFFSET)
+    pre_orig = _chunks_before_offset(
+        orig, _INSERT_OFFSET
+    )
     pre_shifted = _chunks_before_offset(
         shifted_chunks, _INSERT_OFFSET
     )
@@ -87,5 +99,39 @@ def test_cdc_buzhash_shift_resilient_prefix() -> None:
         "No chunks before insert point"
     )
     assert pre_orig == pre_shifted, (
-        "Chunks before insert point changed after insertion"
+        "Chunks before insert point changed"
+        " after insertion"
+    )
+
+
+def test_cdc_buzhash_shift_resilient_prefix() -> None:
+    _assert_prefix_invariant(iter_cdc_buzhash)
+
+
+def test_cdc_rabin_shift_resilient_prefix() -> None:
+    _assert_prefix_invariant(iter_cdc_rabin)
+
+
+def test_cdc_buzhash_shift_resilient_suffix_reuse() -> None:
+    """BuzHash: most chunks are reused after 1-byte insert."""
+    data = _make_data()
+    shifted = _make_shifted()
+
+    orig = list(
+        iter_cdc_buzhash(io.BytesIO(data), _CFG_SHIFT)
+    )
+    shifted_chunks = list(
+        iter_cdc_buzhash(io.BytesIO(shifted), _CFG_SHIFT)
+    )
+
+    orig_set = set(orig)
+    reuse_count = len(orig_set & set(shifted_chunks))
+    total = len(orig_set)
+
+    assert total >= 2, "Not enough unique chunks"
+    # Allow up to 3 chunks to differ: 1-byte insertion
+    # affects only the chunk straddling the insert point
+    # plus at most 2 neighbours before CDC re-converges.
+    assert reuse_count >= total - 3, (
+        f"Too few reused chunks: {reuse_count}/{total}"
     )


### PR DESCRIPTION
## Summary
- Add `/ship` skill that combines commit + PR creation + optional squash-merge into a single workflow
- Supports target branch as first argument (default: main)
- Supports `merge=true` flag for automatic squash-merge with CI-pending handling (Wait/Force/Skip)
- Includes shift-resilient CDC tests (T-028b/c)

## Test plan
- [ ] `/ship` — commit + PR to main
- [ ] `/ship develop` — commit + PR to develop
- [ ] `/ship merge=true` — commit + PR + squash-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)