### PR TITLE
feat: add /scout and /impl skills, refine plan2doc + planner

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -4,35 +4,18 @@ description: "Create detailed implementation plans for features and refactoring.
 tools:
   - Read
   - Write
+  - Edit
   - Grep
   - Glob
+  - "Bash(git:*)"
 model: opus
 maxTurns: 30
 permissionMode: acceptEdits
 skills:
   - seedbraid-conventions
-  - sbd1-format
 ---
 
-You are a software architect. Create detailed, actionable implementation plans.
-
-## Instructions
-
-1. Analyze the feature/change request and explore relevant code
-2. Identify dependencies, affected files, risks, and implementation order
-3. Read `.docs/templates/workflow-patterns.md` to understand available workflow patterns
-4. Read `.claude/agents/` and `.claude/skills/` to identify available tools
-5. Write the full plan to `.docs/plans/{feature}.md` including:
-   - Overview and goals
-   - Affected files and components
-   - Step-by-step implementation plan (numbered)
-   - Risk assessment and testing strategy
-   - `### Claude Code Workflow` section with phase/command/agent table and execution example
-6. For the Claude Code Workflow section:
-   - Determine the ticket's category (Security/CodeQuality/Doc/DevOps/Community) and size (S/M/L/XL)
-   - Select the matching pattern from `.docs/templates/workflow-patterns.md`
-   - Customize the pattern based on the specific ticket's requirements
-7. Return only a summary to the caller
+You are a software architect. Follow the instructions provided by the caller (plan2doc skill). The caller specifies the steps and output format — execute them faithfully.
 
 ## Context Conservation Protocol
 
@@ -45,5 +28,5 @@ You are a software architect. Create detailed, actionable implementation plans.
 **Status**: success | partial | failed
 **Output**: [plan file path]
 **Summary**: [200 words or less overview]
-**Steps**: [numbered implementation steps, one line each]
+**Steps**: [numbered implementation steps, one line each, max 10]
 **Next Steps**: [recommended actions]

--- a/.claude/skills/impl/SKILL.md
+++ b/.claude/skills/impl/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: impl
+description: >-
+  Implement the latest plan with optional additional instructions.
+  Runs implementation, lint, test loop, and simplify review.
+  Use after /scout or /plan2doc to execute the plan.
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - Grep
+  - "Bash(UV_CACHE_DIR=.uv-cache uv run:*)"
+  - "Bash(PYTHONPATH=src uv run:*)"
+  - "Bash(git status:*)"
+  - "Bash(git diff:*)"
+  - "Bash(mkdir:*)"
+  - "Bash(ls:*)"
+  - Skill
+argument-hint: "[additional instructions (optional)]"
+---
+
+Implement the latest plan.
+Additional instructions from user: $ARGUMENTS
+
+## Pre-computed Context
+
+Latest plan:
+!`ls -t .docs/plans/*.md 2>/dev/null | head -1`
+
+Latest research:
+!`ls -t .docs/research/*.md 2>/dev/null | head -1`
+
+Current state:
+!`git status --short`
+
+Current branch:
+!`git branch --show-current`
+
+## Phase 1: Plan Loading
+
+1. If no plan file is listed above, print "No plan found in .docs/plans/. Run /scout or /plan2doc first." and stop.
+2. Read the latest plan file content.
+3. If a related research file exists in `.docs/research/`, read it for additional context.
+4. If `$ARGUMENTS` contains additional instructions, integrate them with the plan (additional instructions take priority on conflicts).
+5. If the working tree has uncommitted changes unrelated to the plan, warn the user before proceeding.
+
+## Phase 2: Implementation
+
+6. Follow the plan's steps to implement code changes, including test code.
+7. Adhere to project constraints: streaming-first (no full-file buffering), SBD1 backward compatibility, ruff line-length=79, Python 3.12+.
+8. If the plan involves format or behavior changes, update `docs/FORMAT.md` and/or `docs/DESIGN.md` first (spec-first policy).
+
+## Phase 3: Lint (max 3 attempts)
+
+9. Run lint: `UV_CACHE_DIR=.uv-cache uv run --no-editable ruff check .`
+10. If lint fails, fix the issues and re-run. Repeat up to 3 attempts.
+11. If lint still fails after 3 attempts, report failures and stop.
+
+## Phase 4: Test (max 3 attempts)
+
+12. Run tests: `PYTHONPATH=src uv run --no-editable python -m pytest -q`
+13. If tests fail, fix the issues and re-run. Repeat up to 3 attempts.
+14. If tests still fail after 3 attempts, report failures and stop.
+
+## Phase 5: Simplify
+
+15. Call `/simplify` via the Skill tool to review the changes.
+16. Print the simplify result summary.
+
+## Phase 6: Post-simplify Verification
+
+17. Check `git diff --stat` to see if simplify made changes.
+18. If changes were made, re-run lint + tests:
+    - `UV_CACHE_DIR=.uv-cache uv run --no-editable ruff check .`
+    - `PYTHONPATH=src uv run --no-editable python -m pytest -q`
+19. If post-simplify tests fail, fix once and re-run. If still failing, report to the user for manual resolution.
+
+## Phase 7: Summary
+
+20. Print a summary including:
+    - Plan file executed
+    - Files changed or created (`git diff --stat`)
+    - Test results (pass/fail count)
+    - Simplify review outcome
+    - Recommended next step: `/ship` to commit and create PR
+
+## Error Handling
+
+- **No plan**: Print "No plan found in .docs/plans/. Run /scout or /plan2doc first." and stop.
+- **Dirty working tree**: Warn user about unrelated changes, ask whether to continue.
+- **Lint 3x failure**: Print failures and stop. Code remains in place.
+- **Test 3x failure**: Print failures and stop. Code remains in place.
+- **Simplify failure**: Print warning and continue (implementation + tests are already complete).
+- **Post-simplify test failure**: Report to user for manual resolution.

--- a/.claude/skills/plan2doc/SKILL.md
+++ b/.claude/skills/plan2doc/SKILL.md
@@ -13,12 +13,15 @@ Create an implementation plan for: $ARGUMENTS
 Current changes:
 !`git diff --stat`
 
+Existing research (if any):
+!`ls -t .docs/research/*.md 2>/dev/null | head -5`
+
 ## Instructions
 
-1. Analyze the feature/change request and explore relevant code
+1. If existing research files are listed above, read them to build on prior findings
 2. Identify dependencies, affected files, risks, and implementation order
-3. Read `.docs/templates/workflow-patterns.md` to understand available workflow patterns
-4. Read `.claude/agents/` and `.claude/skills/` to identify available tools
+3. Read `.docs/templates/workflow-patterns.md` if it exists (skip if missing)
+4. Scan `.claude/agents/` and `.claude/skills/` frontmatter only (not full file contents) to identify available tools
 5. Write the full plan to `.docs/plans/{feature}.md` including:
    - Overview and goals
    - Affected files and components
@@ -26,4 +29,9 @@ Current changes:
    - Risk assessment and testing strategy
    - `### Claude Code Workflow` section with phase/command/agent table
 6. Return a summary with the plan file path
-7. Recommend: "Start a new session with /catchup for implementation"
+
+## Error Handling
+
+- **Empty arguments**: Print "Usage: /plan2doc <feature or change to plan>" and stop.
+- **Missing .docs/ directories**: Create `.docs/plans/` automatically.
+- **Missing workflow-patterns.md**: Skip the workflow pattern selection step; generate the Claude Code Workflow section from available skills/agents directly.

--- a/.claude/skills/scout/SKILL.md
+++ b/.claude/skills/scout/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: scout
+description: >-
+  Investigate codebase and create an implementation plan by chaining
+  /investigate (researcher, sonnet) and /plan2doc (planner, opus).
+  Use when you need both research and planning for a feature or ticket.
+disable-model-invocation: true
+allowed-tools:
+  - Skill
+argument-hint: "<topic or ticket to investigate and plan>"
+---
+
+Investigate and plan: $ARGUMENTS
+
+## Instructions
+
+1. Call `/investigate` with the topic to run codebase research via the researcher agent (sonnet).
+2. If investigate returns a failure status, print the error and stop.
+3. Print the research summary and file path returned by investigate.
+4. Call `/plan2doc` with the same topic to create an implementation plan via the planner agent (opus). The planner will read the research output from `.docs/research/` automatically.
+5. Print the plan summary and file path returned by plan2doc.
+6. Print a final summary with both file paths.
+
+## Error Handling
+
+- **Empty arguments**: Print "Usage: /scout <topic or ticket>" and stop.
+- **investigate failure**: Print the error, do NOT proceed to plan2doc.
+- **plan2doc failure**: Print the error and the research file path (research is still valid).


### PR DESCRIPTION
## Summary
- Add `/scout` skill: chains `/investigate` (researcher/sonnet) + `/plan2doc` (planner/opus) for ~48% cost reduction on investigation phase
- Add `/impl` skill: plan execution with lint/test loop (max 3 retries each) + `/simplify` review (3 parallel opus agents) + post-simplify verification
- Refine `plan2doc`: planning-only focus, existing research context, error handling
- Refine `planner` agent: caller-delegated instructions, added Edit + Bash(git:*) tools

## Test plan
- [x] `/scout` test execution verified — researcher(sonnet) + planner(opus) confirmed via JSONL logs
- [x] `/simplify` subagent verification — 3 parallel opus agents confirmed
- [ ] `/impl` end-to-end test (requires active plan in .docs/plans/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)