### PR TITLE
fix: remove model override from release skill to avoid spurious rate limit

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -4,7 +4,6 @@ description: >-
   Create a release: version bump, changelog, PR, tag, and GitHub Release.
   Requires gh command. Use only when the user explicitly requests a release.
 disable-model-invocation: true
-model: sonnet
 allowed-tools:
   - "Bash(git:*)"
   - "Bash(gh:*)"


### PR DESCRIPTION
## Summary
- Remove `model: sonnet` from `/release` skill frontmatter
- Fixes spurious "API Error: Rate limit reached" when invoking `/release` with Opus as the conversation default model
- The inline Opus → Sonnet model switch in direct execution skills triggers a rate limit error even when Sonnet usage is at 2%

## Root Cause
Direct execution skills (non-forked) with `model: sonnet` that switch from the conversation's default Opus model hit an internal routing constraint. Forked agent skills with the same `model: sonnet` are unaffected.

## Test plan
- [x] `/release` now executes without rate limit error (verified by successful v2.0.3 release using natural language after applying workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)