### PR TITLE
fix: allow git reset --hard origin/<branch> in safety hook

### DIFF
--- a/.claude/hooks/pre-bash-safety.sh
+++ b/.claude/hooks/pre-bash-safety.sh
@@ -10,8 +10,13 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 DESTRUCTIVE='(^|[|;&])\s*(env\s+|command\s+)?(rm\s+-[a-z]*r[a-z]*f|rm\s+-[a-z]*f[a-z]*r|git\s+push\s+(--force|--force-with-lease|-f)\b|git\s+reset\s+--hard|git\s+clean\s+-[a-z]*f|DROP\s+(TABLE|DATABASE))'
 
 if echo "$COMMAND" | grep -qE "$DESTRUCTIVE"; then
-  echo "Blocked: destructive command not allowed: $COMMAND" >&2
-  exit 2
+  # Allow git reset --hard origin/<branch> (safe remote sync)
+  if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard\s+origin/[A-Za-z0-9._/-]+\s*($|[;&|])'; then
+    : # permitted — resetting to a remote tracking ref
+  else
+    echo "Blocked: destructive command not allowed: $COMMAND" >&2
+    exit 2
+  fi
 fi
 
 # --- Sensitive file staging patterns (T-029 S-4) ---


### PR DESCRIPTION
## Summary
- Relax `pre-bash-safety.sh` to allow `git reset --hard origin/<branch>` (remote sync) while continuing to block bare `git reset --hard`, `HEAD~N` resets, and other destructive patterns
- Enables autonomous post-squash-merge local sync without user intervention

## Context
After squash-merge in `/ship`, local main diverges from remote. The only clean sync is `git reset --hard origin/main`, which was unconditionally blocked by T-029 safety hook.

## Test plan
- [x] `git reset --hard origin/main` → allowed
- [x] `git reset --hard origin/develop` → allowed
- [x] `git reset --hard origin/feat/x` → allowed
- [x] `git reset --hard` (bare) → blocked
- [x] `git reset --hard HEAD~3` → blocked
- [x] `git push -f` → blocked
- [x] `git clean -fd` → blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)